### PR TITLE
Make $requestId not nullable

### DIFF
--- a/src/Communication/Request.php
+++ b/src/Communication/Request.php
@@ -11,7 +11,7 @@ namespace Aternos\Taskmaster\Communication;
  */
 class Request extends Message implements RequestInterface
 {
-    protected ?string $requestId = null;
+    protected string $requestId;
 
     /**
      * Request constructor.


### PR DESCRIPTION
`$requestId` is never null because it is initialized with `uniqid()` in the constructor.