### PR TITLE
Extract $socket from constructor property promotion

### DIFF
--- a/src/Communication/Socket/Socket.php
+++ b/src/Communication/Socket/Socket.php
@@ -20,7 +20,7 @@ class Socket implements SocketInterface, SelectableSocketInterface
     /**
      * @var resource
      */
-    protected $socket;
+    protected mixed $socket;
 
     /**
      * @param resource|Socket $socket

--- a/src/Communication/Socket/Socket.php
+++ b/src/Communication/Socket/Socket.php
@@ -16,13 +16,21 @@ use Generator;
  */
 class Socket implements SocketInterface, SelectableSocketInterface
 {
+
+    /**
+     * @var resource
+     */
+    protected $socket;
+
     /**
      * @param resource|Socket $socket
      */
-    public function __construct(protected mixed $socket)
+    public function __construct(mixed $socket)
     {
-        if ($this->socket instanceof Socket) {
-            $this->socket = $this->socket->getStream();
+        if ($socket instanceof Socket) {
+            $this->socket = $socket->getStream();
+        } else {
+            $this->socket = $socket;
         }
         stream_set_blocking($this->socket, false);
     }


### PR DESCRIPTION
Extract `$socket` from constructor property promotion and make it a normal class member with type `resource` instead of `resource|Socket`.
This will make it clear that `$socket` is always of type `resource`.
