### PR TITLE
Open std streams if STDIN, STDOUT, or STDERR are not defined

### DIFF
--- a/src/Communication/StdStreams.php
+++ b/src/Communication/StdStreams.php
@@ -4,7 +4,7 @@ namespace Aternos\Taskmaster\Communication;
 
 class StdStreams
 {
-    protected static self $instance;
+    protected static ?self $instance = null;
 
     /**
      * @var resource|null
@@ -26,7 +26,7 @@ class StdStreams
      */
     public static function getInstance(): static
     {
-        if (!isset(self::$instance)) {
+        if (self::$instance === null) {
             self::$instance = new static();
         }
         return self::$instance;

--- a/src/Communication/StdStreams.php
+++ b/src/Communication/StdStreams.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Aternos\Taskmaster\Communication;
+
+class StdStreams
+{
+    protected static self $instance;
+
+    /**
+     * @var resource|null
+     */
+    protected $stdin = null;
+
+    /**
+     * @var resource|null
+     */
+    protected $stdout = null;
+
+    /**
+     * @var resource|null
+     */
+    protected $stderr = null;
+
+    /**
+     * @return static
+     */
+    public static function getInstance(): static
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new static();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getStdin()
+    {
+        if ($this->stdin === null) {
+            if (defined("STDIN")) {
+                $this->stdin = STDIN;
+            } else {
+                $this->stdin = fopen("php://stdin", "r");
+            }
+        }
+
+        return $this->stdin;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getStdout()
+    {
+        if ($this->stdout === null) {
+            if (defined("STDOUT")) {
+                $this->stdout = STDOUT;
+            } else {
+                $this->stdout = fopen("php://stdout", "w");
+            }
+        }
+
+        return $this->stdout;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getStderr()
+    {
+        if ($this->stderr === null) {
+            if (defined("STDERR")) {
+                $this->stderr = STDERR;
+            } else {
+                $this->stderr = fopen("php://stderr", "w");
+            }
+        }
+
+        return $this->stderr;
+    }
+}

--- a/src/Communication/StdStreams.php
+++ b/src/Communication/StdStreams.php
@@ -26,10 +26,10 @@ class StdStreams
      */
     public static function getInstance(): static
     {
-        if (self::$instance === null) {
-            self::$instance = new static();
+        if (static::$instance === null) {
+            static::$instance = new static();
         }
-        return self::$instance;
+        return static::$instance;
     }
 
     /**

--- a/src/Runtime/RuntimeProcess.php
+++ b/src/Runtime/RuntimeProcess.php
@@ -4,6 +4,7 @@ namespace Aternos\Taskmaster\Runtime;
 
 use Aternos\Taskmaster\Communication\Socket\SocketInterface;
 use Aternos\Taskmaster\Communication\Socket\SocketPair;
+use Aternos\Taskmaster\Communication\StdStreams;
 use Aternos\Taskmaster\TaskmasterOptions;
 
 /**
@@ -33,15 +34,16 @@ class RuntimeProcess
     {
         $socketPair = new SocketPair();
         $this->socket = $socketPair->getParentSocket();
+        $stdStreams = StdStreams::getInstance();
         $this->process = proc_open([
             $options->getPhpExecutable(),
             static::BIN_PATH,
             $options->getBootstrap(),
             $runtimeClass
         ], [
-            0 => STDIN,
-            1 => STDOUT,
-            2 => STDERR,
+            0 => $stdStreams->getStdin(),
+            1 => $stdStreams->getStdout(),
+            2 => $stdStreams->getStderr(),
             3 => $socketPair->getChildSocket()->getStream(),
         ], $pipes);
         $socketPair->closeChildSocket();


### PR DESCRIPTION
`STDIN`, `STDOUT`, and `STDERR` are only defined in CLI environments: https://www.php.net/manual/en/reserved.constants.php#constant.stdout

This pull request adds a `StdStreams` singleton class which provides access to the std streams, either by using the constants or by opening the streams using `fopen` if the constants are not defined.