### PR TITLE
Use StdStreams instead of STDERR constant for error output

### DIFF
--- a/src/Proxy/ProxyRuntime.php
+++ b/src/Proxy/ProxyRuntime.php
@@ -12,6 +12,7 @@ use Aternos\Taskmaster\Communication\Socket\Exception\SocketReadException;
 use Aternos\Taskmaster\Communication\Socket\Exception\SocketWriteException;
 use Aternos\Taskmaster\Communication\Socket\SelectableSocketInterface;
 use Aternos\Taskmaster\Communication\Socket\SocketCommunicatorTrait;
+use Aternos\Taskmaster\Communication\StdStreams;
 use Aternos\Taskmaster\Runtime\AsyncRuntimeInterface;
 use Aternos\Taskmaster\Taskmaster;
 use Aternos\Taskmaster\Worker\Instance\ProxyableWorkerInstanceInterface;
@@ -244,7 +245,7 @@ class ProxyRuntime implements AsyncRuntimeInterface
         if ($reason instanceof Exception) {
             $reason = $reason->getMessage();
         }
-        fwrite(STDERR, "Proxy runtime failed: " . $reason . PHP_EOL);
+        fwrite(StdStreams::getInstance()->getStderr(), "Proxy runtime failed: " . $reason . PHP_EOL);
         exit(1);
     }
 }

--- a/src/Runtime/SocketRuntime.php
+++ b/src/Runtime/SocketRuntime.php
@@ -8,6 +8,7 @@ use Aternos\Taskmaster\Communication\Socket\SelectableSocketInterface;
 use Aternos\Taskmaster\Communication\Socket\Socket;
 use Aternos\Taskmaster\Communication\Socket\SocketCommunicatorTrait;
 use Aternos\Taskmaster\Communication\Socket\SocketInterface;
+use Aternos\Taskmaster\Communication\StdStreams;
 use Aternos\Taskmaster\Exception\PhpError;
 use Aternos\Taskmaster\Exception\PhpFatalErrorException;
 use Aternos\Taskmaster\Taskmaster;
@@ -102,7 +103,7 @@ class SocketRuntime extends Runtime implements AsyncRuntimeInterface
         if ($reason instanceof Exception) {
             $reason = $reason->getMessage();
         }
-        fwrite(STDERR, "Runtime failed: " . $reason . PHP_EOL);
+        fwrite(StdStreams::getInstance()->getStderr(), "Runtime failed: " . $reason . PHP_EOL);
         exit(1);
     }
 }

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -6,6 +6,7 @@ use Aternos\Taskmaster\Communication\Promise\ResponseDataPromise;
 use Aternos\Taskmaster\Communication\Promise\TaskPromise;
 use Aternos\Taskmaster\Communication\Request\ExecuteFunctionRequest;
 use Aternos\Taskmaster\Communication\ResponseInterface;
+use Aternos\Taskmaster\Communication\StdStreams;
 use Aternos\Taskmaster\Exception\PhpError;
 use Aternos\Taskmaster\Runtime\RuntimeInterface;
 use Closure;
@@ -175,7 +176,7 @@ abstract class Task implements TaskInterface
     public function handleError(Exception $error): void
     {
         $this->error = $error;
-        fwrite(STDERR, $error->getMessage() . PHP_EOL);
+        fwrite(StdStreams::getInstance()->getStderr(), $error->getMessage() . PHP_EOL);
     }
 
     /**


### PR DESCRIPTION
The STDERR constant does not exist in all environments